### PR TITLE
ci(evaluation): network isolation

### DIFF
--- a/.github/workflows/algorithm-evaluation.yml
+++ b/.github/workflows/algorithm-evaluation.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Execute algorithm container
-        if: ${{ steps.find-algorithm.outputs.any_changed != "false" }}
+        if: steps.find-algorithm.outputs.any_changed == 'false'
         run: |
           # iterate over all datasets in S3
           for recording in $(aws s3api list-objects --bucket ${AWS_BUCKET} --prefix datasets --output text --query 'Contents[].[Key]' | grep '.*edf'); do

--- a/.github/workflows/algorithm-evaluation.yml
+++ b/.github/workflows/algorithm-evaluation.yml
@@ -44,8 +44,6 @@ jobs:
               touch ./predictions/tmp.tsv
               chmod 776 ./predictions/tmp.tsv
 
-              # Create restricted network for docker image execution
-              docker network create --driver bridge isolated_network
 
               echo "Running inference for $ALGO_NAME"
               docker run \
@@ -53,7 +51,7 @@ jobs:
                 -e OUTPUT=tmp.tsv \
                 -v ./predictions:/output:rw \
                 -v ./data:/data:ro \
-                --network isolated_network \
+                --network none \
                 --name "${ALGO_NAME}" \
                 "${IMAGE}"
 
@@ -67,7 +65,6 @@ jobs:
               # Cleanup
               rm ./predictions/tmp.tsv
               docker rm "${ALGO_NAME}"
-              docker network rm isolated_network
             done
             # Cleanup
             rm ./data/tmp.edf


### PR DESCRIPTION
Fixes network isolatioon in evaluation CI.

Before, a custom bridge network was created; this isolates the image from other docker images on the host, but bridge networks are connected to the web.

Instead, this PR uses the default `none` network, which uses the 'null' driver, completely disconnecting it from the network.
