### PR TITLE
fix(docker): I/O variables for algo template

### DIFF
--- a/config/template.Dockerfile
+++ b/config/template.Dockerfile
@@ -50,4 +50,4 @@ ENV INPUT=""
 ENV OUTPUT=""
 # Run the application
 # NOTE: edit the second command
-CMD python3 -m algo "/data/${INPUT_FILE}" "/output/${OUTPUT_FILE}"
+CMD python3 -m algo "/data/${INPUT}" "/output/${OUTPUT}"


### PR DESCRIPTION
Looks like the env variabls were wrong in the dockerfile template. We also use INPUT/OUTPUT and not INPUT_FILE/OUTPUT_FILE in CI.